### PR TITLE
Adding memoization

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,13 @@
  */
 
 var debug = require('debug')('duo-parse');
+var memoize = require('memoize-sync');
 
 /**
  * Export `parse`
  */
 
-module.exports = parse;
+module.exports = memoize(parse);
 
 /**
  * Parse the given `slug`.

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "eslint-config-duo": "0.0.1",
     "expect.js": "^0.3.1",
     "istanbul": "^0.3.2",
-    "mocha": "^2.2.5"
+    "mocha": "^2.2.5",
+    "timed": "^0.1.1"
   },
   "dependencies": {
-    "debug": "^2.2.0"
+    "debug": "^2.2.0",
+    "memoize-sync": "0.0.2"
   }
 }

--- a/test/parse.js
+++ b/test/parse.js
@@ -3,6 +3,7 @@
  */
 
 var expect = require('expect.js');
+var timed = require('timed');
 var parse = require('..');
 
 /**
@@ -178,5 +179,17 @@ describe('parse()', function(){
         provider: 'github.com'
       });
     });
+  });
+
+  it('should be memoized', function(){
+    timed.reset();
+    parse('component/each');
+    var goal = timed.since() / 5;
+
+    timed.reset();
+    parse('component/each');
+    var actual = timed.since();
+
+    expect(actual).to.be.below(goal);
   });
 });


### PR DESCRIPTION
I've noticed in duo at least we cache the results of this function, there's no reason to not bake memoization right into this module itself.